### PR TITLE
Converted curl subprocess commands to use urllib instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Syntax
 
 Commands
 ------------
-- `--add-dns` : Attempts to add a DNS entry to Unbound (DNS Resolver). This requires both TCP/443 and UDP/53 access from the host. 
+- `--add-dns` : Attempts to add a DNS entry to Unbound (DNS Resolver). This will not overwrite existing DNS entries
     - **Syntax**: `pfsense-automator <pfSense IP or hostname> --add-dns <subdomain> <primary_domain> <IP> <description>`
     - **Arguments**: 
         - `<subdomain>` : Specify the subdomain of the DNS entry (SUBDOMAIN.primarydomain.com)


### PR DESCRIPTION
- Replaced subprocess commands with urllib functions
- Replaced check_dns() to check DNS Resolver (Unbound)'s local configuration instead of resolving DNS entries
- Added get_dns_entries() to return a dictionary of configured DNS entries, this will return the entires hostname, domain name, IP address, description and config ID which we can use in the future to modify or delete DNS entries
- Removed subprocess module
- Updated exit code dictionary and README.md

Note: the script should now be platform independent as long as the local machine has the requests module installed